### PR TITLE
Fix code example in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,17 +28,17 @@ const json = `{
   "hello": "world"
 }`
 
-console.log(json, {
+console.log(transform(json, {
   lang: "typescript"
-})
+}))
 
 // interface RootJson {
 //   hello: string
 // }
 
-console.log(json, {
-	lang: "rust"
-})
+console.log(transform(json, {
+	lang: "rust-serde"
+}))
 
 // #[derive(Serialize, Deserialize)]
 // struct RootInterface {


### PR DESCRIPTION
A minor fix for the readme. The code example should call the `transform` function, and the rust mapping identifier is "rust-serde".